### PR TITLE
Fix wording in the backingStore domintro

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -556,7 +556,7 @@ To <dfn lt="deleting the database|delete the database">delete the database</dfn>
 <dl class="domintro non-normative">
   <dt><code>{ |database|, |store|, |version| } = |storage|.{{StorageArea/backingStore}}</code>
   <dd>
-    <p>Asynchronously retrieves an an object containing all of the information necessary to manually interface with the IndexedDB backing store that underlies this storage area:
+    <p>Returns an object containing all of the information necessary to manually interface with the IndexedDB backing store that underlies this storage area:
 
     * |database| will be a string equal to "<code>kv-storage:</code>" concatenated with the database name passed to the constructor. (For the default storage area, it will be "<code>kv-storage:default</code>".)
     * |store| will be the string "<code>store</code>".
@@ -840,7 +840,9 @@ Andrew Sutherland,
 Kenneth Rohde Christiansen,
 Jake Archibald,
 Jan Varga,
-Joshua Bell, and
+Joshua Bell,
+Ms2ger,
+and
 Victor Costan
 for their contributions to this specification.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/kv-storage/pull/64.html" title="Last updated on Apr 29, 2019, 8:48 AM UTC (bbc9864)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/kv-storage/64/f2af4aa...Ms2ger:bbc9864.html" title="Last updated on Apr 29, 2019, 8:48 AM UTC (bbc9864)">Diff</a>